### PR TITLE
Add quickstart development instructions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -58,16 +58,14 @@ To run quality quality::
 Tutor Devstack Installation Instructions
 ########################################
 
-You need to have `tvm <https://github.com/eduNEXT/tvm/>`_ installed in your machine as well as
+You need to have
 `Tutor requirements such as Docker <https://docs.tutor.edly.io/install.html#requirements>`_.
 
 Run the following commands::
 
     cd ~/work/
-    tvm install v13.3.2
-    tvm project init payfort v13.3.2  # Create a new Tutor project with Maple Open edX release
-    cd payfort
-    source .tvm/bin/activate  # Use `tutor`
+    sudo pip install tutor==13.3.2
+    mkdir payfort && cd payfort
     git clone git@github.com:Zeit-Labs/ecommerce-payfort.git
     git clone --branch=open-release/maple.nelp git@github.com:eduNEXT/ecommerce.git
     git clone --branch=nelp/maple git@github.com:eduNEXT/tutor-discovery discovery

--- a/README.rst
+++ b/README.rst
@@ -32,9 +32,6 @@ When the testing account is used,
 Development and Testing
 #######################
 
-TBD: Add devstck and Tutor instructions.
-
-
 To run tests locally in your machine, you need to install the following dependencies::
 
    $ pip install tox
@@ -56,6 +53,26 @@ To run quality quality::
 ``tox`` can be used directly to run a specific, for example::
 
    $ tox -e py38 -- tests/unit/test_payfort_utils.py
+
+
+Tutor Devstack Installation Instructions
+########################################
+
+You need to have `tvm <https://github.com/eduNEXT/tvm/>`_ installed in your machine as well as
+`Tutor requirements such as Docker <https://docs.tutor.edly.io/install.html#requirements>`_.
+
+Run the following commands::
+
+    cd ~/work/
+    tvm install v13.3.2
+    tvm project init payfort v13.3.2  # Create a new Tutor project with Maple Open edX release
+    cd payfort
+    source .tvm/bin/activate  # Use `tutor`
+    git clone git@github.com:Zeit-Labs/ecommerce-payfort.git
+    git clone --branch=open-release/maple.nelp git@github.com:eduNEXT/ecommerce.git
+    git clone --branch=nelp/maple git@github.com:eduNEXT/tutor-discovery discovery
+    bash ecommerce-payfort/tutor_plugin/tutor_quickstart.sh
+
 
 
 Installation and usage

--- a/tutor_plugin/README.rst
+++ b/tutor_plugin/README.rst
@@ -1,0 +1,3 @@
+This is hacky plugin to install ecommerce-payfort into Tutor Maple v13.
+
+Follow the ecommerce-payfort/README.rst instructions to install the plugin.

--- a/tutor_plugin/docker-compose.override.yml
+++ b/tutor_plugin/docker-compose.override.yml
@@ -1,0 +1,6 @@
+version: "3.7"
+services:
+  ecommerce:
+    volumes:
+      - PAYFORT_PACKAGE_DIR:/openedx/ecommerce-payfort
+      - ECOMMERCE_DIR:/openedx/ecommerce

--- a/tutor_plugin/ecommerce-config.yml
+++ b/tutor_plugin/ecommerce-config.yml
@@ -1,0 +1,15 @@
+  cybersource:
+      merchant_id: SET-ME-PLEASE
+      flex_shared_secret_key_id: SET-ME-PLEASE
+      flex_shared_secret_key: SET-ME-PLEASE
+      soap_api_url: https://ics2wstest.ic3.com/commerce/1.x/transactionProcessor/CyberSourceTransaction_1.140.wsdl
+      transaction_key: SET-ME-PLEASE
+  paypal:
+    cancel_checkout_path: /checkout/cancel-checkout/
+    client_id: SET-ME-PLEASE
+    client_secret: SET-ME-PLEASE
+    error_url: /checkout/error/
+    mode: sandbox
+    receipt_url: /checkout/receipt/
+  payfort:
+    some_configs: "Yes, payfort's working!"

--- a/tutor_plugin/plugin.py
+++ b/tutor_plugin/plugin.py
@@ -1,0 +1,2 @@
+from tutor import hooks
+

--- a/tutor_plugin/tutor_quickstart.sh
+++ b/tutor_plugin/tutor_quickstart.sh
@@ -4,13 +4,13 @@ SCRIPT_DIR="$( cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
 PAYFORT_PACKAGE_DIR="$(dirname "$SCRIPT_DIR")"
 ECOMMERCE_DIR="$(dirname "$PAYFORT_PACKAGE_DIR")/ecommerce"
 
-if [ -z "$TVM_PROJECT_ENV" ]; then
-  echo "Error: activate tvm project environment first: "
-  echo
-  echo "  $ source .tvm/bin/activate"
-  echo
-  exit 1
-fi
+##if [ -z "$TVM_PROJECT_ENV" ]; then
+##  echo "Error: activate tvm project environment first: "
+##  echo
+##  echo "  $ source .tvm/bin/activate"
+##  echo
+##  exit 1
+##fi
 
 
 set -x

--- a/tutor_plugin/tutor_quickstart.sh
+++ b/tutor_plugin/tutor_quickstart.sh
@@ -1,0 +1,49 @@
+set -e
+
+SCRIPT_DIR="$( cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
+PAYFORT_PACKAGE_DIR="$(dirname "$SCRIPT_DIR")"
+ECOMMERCE_DIR="$(dirname "$PAYFORT_PACKAGE_DIR")/ecommerce"
+
+if [ -z "$TVM_PROJECT_ENV" ]; then
+  echo "Error: activate tvm project environment first: "
+  echo
+  echo "  $ source .tvm/bin/activate"
+  echo
+  exit 1
+fi
+
+
+set -x
+
+
+tutor config save \
+  --set 'ECOMMERCE_EXTRA_PIP_REQUIREMENTS=["-e /openedx/ecommerce-payfort"]'
+
+cat "$SCRIPT_DIR/docker-compose.override.yml" \
+  | sed -e "s|PAYFORT_PACKAGE_DIR|${PAYFORT_PACKAGE_DIR}|g" \
+  | sed -e "s|ECOMMERCE_DIR|${ECOMMERCE_DIR}|g" \
+  > "$(tutor config printroot)/env/dev/docker-compose.override.yml"
+
+pip install \
+  tutor-mfe==13.0.6 \
+  tutor-ecommerce==13.0.1
+
+pip install -e discovery
+
+tutor plugins enable ecommerce
+tutor plugins enable discovery
+tutor plugins enable mfe
+tutor config save --set "DISCOVERY_DB_PREVIOUS_PARTNERS=false"  # NELC specific setting: https://github.com/eduNEXT/tutor-discovery/pull/1
+
+tutor config save --set "ECOMMERCE_PAYMENT_PROCESSORS=$(cat "$SCRIPT_DIR/ecommerce-config.yml")"
+tutor config save
+
+tutor dev quickstart --non-interactive
+
+tutor dev createuser --staff --superuser edx edx@example.com --password edx
+
+tutor dev importdemocourse
+
+tutor dev run ecommerce npm install
+tutor dev run ecommerce ./node_modules/.bin/bower install --allow-root
+tutor dev run ecommerce python3 manage.py update_assets --skip-collect


### PR DESCRIPTION
This plugin will be integrated it into [NELC devstack](https://github.com/nelc/nelc-dev-kit/), but these instructions are useful to test the plugin on Maple without needing to install [eduNEXT tenants](https://github.com/eduNEXT/eox-tenant).

This will build a Tutor devstack with few branches selected for @nelc. For more info see https://docs.tutor.edly.io/.